### PR TITLE
Allow changing of session cookie expiry.

### DIFF
--- a/lib/Catalyst/Plugin/Session/State/Cookie.pm
+++ b/lib/Catalyst/Plugin/Session/State/Cookie.pm
@@ -253,7 +253,7 @@ a browser is not aware of HTTPOnly the flag will be ignored.
 
 Default value is 1.
 
-Note1: Many peole are confused by the name "HTTPOnly" - it B<does not mean>
+Note1: Many people are confused by the name "HTTPOnly" - it B<does not mean>
 that this cookie works only over HTTP and not over HTTPS.
 
 Note2: This parameter requires Catalyst::Runtime 5.80005 otherwise is skipped.

--- a/t/lib/CookieTestApp/Controller/Root.pm
+++ b/t/lib/CookieTestApp/Controller/Root.pm
@@ -19,6 +19,13 @@ sub stream : Local {
     $c->res->write($count);
 }
 
+sub set_session_cookie_expire : Local {
+    my ( $self, $c, $val ) = @_;
+    $val = undef if $val eq 'undef';
+    $c->set_session_cookie_expire($val);
+    $c->res->body('expire_with_browser_session');
+}
+
 sub deleteme : Local {
     my ( $self, $c ) = @_;
     my $id = $c->get_session_id;

--- a/t/live_app.t
+++ b/t/live_app.t
@@ -54,6 +54,21 @@ $m->content_contains( "hit number 6", "session data restored" );
 $m->cookie_jar->scan( sub { $updated_expired = $_[8]; } );
 cmp_ok( $expired, "<", $updated_expired, "streaming also extends cookie" );
 
+# set the cookie to expire in 5 minutes
+$m->get_ok( "/set_session_cookie_expire/300", "set expire to 300" );
+$m->cookie_jar->scan( sub { $expired = $_[8]; } );
+cmp_ok( $expired, '<=', ( time + 300 ), "cookie will expire within 5 minutes" );
+
+# set the cookie to expire at end of session
+$m->get_ok( "/set_session_cookie_expire/0", "set expire to 0" );
+$m->cookie_jar->scan( sub { $expired = $_[8]; } );
+ok( !defined $expired, "cookie will now expire with browser session" );
+
+# restore to default (3600 - so test for >= now+3500)
+$m->get_ok( "/set_session_cookie_expire/undef", "set expire to undef" );
+$m->cookie_jar->scan( sub { $expired = $_[8]; } );
+cmp_ok( $expired, '>=', ( time + 3500 ), "cookie expiry reset to default" );
+
 $m->get_ok( "http://localhost/deleteme", "get page" );
 $m->content_is( 1, 'session id changed' );
 


### PR DESCRIPTION
Add a set_session_cookie_expire function that lets you change the expiry
for the current session's cookie. You can set a number of seconds, 0 to
expire the cookie when the browser quits or undef to fallback to the
configured defaults.

Written by Edmund von der Burg, tweaked by me.
